### PR TITLE
tsdb/cloudwatch: always return underlying metrics query errors

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -699,7 +699,7 @@ func (e *CloudWatchExecutor) ec2DescribeInstances(region string, filters []*ec2.
 			return !lastPage
 		})
 	if err != nil {
-		return nil, errors.New("Failed to call ec2:DescribeInstances")
+		return nil, fmt.Errorf("Failed to call ec2:DescribeInstances, %v", err)
 	}
 
 	return &resp, nil
@@ -721,7 +721,7 @@ func (e *CloudWatchExecutor) resourceGroupsGetResources(region string, filters [
 			return !lastPage
 		})
 	if err != nil {
-		return nil, errors.New("Failed to call tags:GetResources")
+		return nil, fmt.Errorf("Failed to call tags:GetResources, %v", err)
 	}
 
 	return &resp, nil


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Some of the methods used to aggregate metrics from CloudWatch do not always include the underlying error. This makes debugging issues related to these metrics a little difficult.

**Which issue(s) this PR fixes**:
N/A

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer**:
N/A

